### PR TITLE
`Smallest-divisor` problem's re-implementation and `Exercise 1.21`

### DIFF
--- a/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Exponentiation/Iterative_successive_squaring/Sources/iterative_exponentiation.scm
+++ b/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Exponentiation/Iterative_successive_squaring/Sources/iterative_exponentiation.scm
@@ -4,7 +4,7 @@
     
     (import scheme)
     
-    (import square_func)    
+    (import square_func)
     
     (define (fast-expt number exponent)
         (fast-expt-iter number exponent 1))

--- a/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Sources/main.scm
+++ b/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Sources/main.scm
@@ -1,0 +1,7 @@
+(include "smallest_divisor.scm")
+
+(import primality)
+
+(smallest-divisor 199)
+(smallest-divisor 1999)
+(smallest-divisor 19999)

--- a/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Sources/smallest_divisor.scm
+++ b/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Sources/smallest_divisor.scm
@@ -1,0 +1,17 @@
+(include "../../../../The_elements_of_programming/Procedures_as_Black_Box_Abstractions/Cube_root_with_lexical_scoping/Square_function/Sources/square.scm")
+
+(module primality (smallest-divisor)
+    
+    (import scheme)
+
+    (import square_func)
+
+    (define (smallest-divisor number)
+        (find-divisor (abs number) 2))
+    
+    (define (find-divisor number possible-divisor)
+        (cond ((> (square possible-divisor) number) number)
+
+              ((= (remainder number possible-divisor) 0) possible-divisor)
+
+              (else (find-divisor number (+ possible-divisor 1))))))

--- a/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Tests/unit_test.scm
+++ b/Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Tests/unit_test.scm
@@ -1,0 +1,16 @@
+(import test)
+
+(include "../Sources/smallest_divisor.scm")
+
+(import primality)
+
+(test-group "'Smallest divisor' tests"
+    (test 2 (smallest-divisor 4))
+    (test 3 (smallest-divisor 9))
+    (test 5 (smallest-divisor 5))
+    (test 19 (smallest-divisor 19))
+    (test 3 (smallest-divisor 39))
+    (test 2 (smallest-divisor (- 4)))
+    (test 5 (smallest-divisor (- 125))))
+
+(test-exit)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all_tests: chicken-module-installer square cube random-positive-number cube-root \
-			tree-recursion-iterative tree-recursion-recursive pascals-triangle exponentiation
+		   tree-recursion-iterative tree-recursion-recursive pascals-triangle exponentiation \
+		   smallest-divisor
 
 chicken-module-installer:
 	chicken-install -s test test-generative srfi-1
@@ -35,3 +36,7 @@ pascals-triangle:
 exponentiation:
 	cd Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Exponentiation/Iterative_successive_squaring/Tests && \
 	$(CSI) unit_test.scm && $(CSI) pbt.scm
+
+smallest-divisor:
+	cd Building_abstractions_with_procedures/Procedures_and_the_processes_they_generate/Testing_for_primality/Exercise_1.21/Tests && \
+	$(CSI) unit_test.scm


### PR DESCRIPTION
1) Added implementation and tests of `smallest-divisor` method
2) Used the method in `main.scm` file to compute values at points 199,
1999 and 19999
3) Fixed formatting of `iterative_exponentiation.scm`