### PR TITLE
Implementing module dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all_tests: chicken-module-installer square cube random-positive-number cube-root
 		   smallest-divisor smallest-divisor-with-next-function
 
 chicken-module-installer:
-	chicken-install -s test test-generative srfi-1
+	./chicken-module-installer.sh $(INSTALL_MISSING_LIBS)
 
 square:
 	cd Building_abstractions_with_procedures/The_elements_of_programming/Procedures_as_Black_Box_Abstractions/Cube_root_with_lexical_scoping/Square_function/Tests && \

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,6 @@
 
 
 To run all the tests via ***make*** command, please type:
-> export CSI=\<interpreter-name\>; make all_tests
+> export CSI=\<interpreter-name\>; make all_tests INSTALL_MISSING_LIBS=y
 
-where \<interpreter-name\> is the name of your interpreter.
+where \<interpreter-name\> is the name of your interpreter and \<INSTALL_MISSING_LIBS=y\> will automatically install all the missing chicken-modules.

--- a/chicken-module-installer.sh
+++ b/chicken-module-installer.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+
+requiredLibs=( "test" "test-generative" )
+installedLibs=($(chicken-status | grep '......' | awk '{print $1}'))
+missingLibs=()
+
+echo "Checking for required libraries..."
+
+for requiredLib in ${requiredLibs[@]}; do
+  libFound=false
+  for installedLib in ${installedLibs[@]}; do
+    if [[ "$installedLib" == "$requiredLib" ]]; then
+      libFound=true
+      break
+    fi
+  done
+  if [[ "$libFound" != true ]]; then
+    missingLibs+=($requiredLib)
+  fi
+done
+
+if [[ ${#missingLibs[@]} -gt 0 ]]; then
+  echo "Missing libraries: ${missingLibs[@]}"
+
+  if [[ "$1" != "y" ]]; then
+    echo "Do you want to install them? (y/n)"
+    read answer
+    
+    if [[ "$answer" != "y" ]]; then
+      echo "Please install the missing libraries manually."
+      exit 1
+    fi
+  else
+    answer="y"
+  fi
+
+  if [[ "$answer" == "y" ]]; then
+    OS=$(uname)
+    
+    if [[ "$OS" == "Darwin" ]] || [[ "$OS" == "Linux" ]]; then
+      chicken-install -s ${missingLibs[@]}
+    else
+      echo "Unsupported OS: $OS"
+      exit 1
+    fi
+  fi
+fi


### PR DESCRIPTION
In this PR we tried to add dependencies for automatic chicken-module installation.
After a discussion, we came up with an idea to compress separate functions and call them after each other. But after trying to do so, I faced some issues. The last part of the `chicken-module-installer.sh` shell script, which described the automated installation of missing `chicken-modules`, did not work after the separation. Hence, the only part, which worked after the separation was the part of finding missing modules. But as a matter of fact, I wrote the whole implementation of the algorithm inside a function, and then I called the function, which, in my opinion, was useless. And additionally, I changed conditional statements safer, by changing `[]` notation with `[[]]`, and kept `[[... -gt 0]]` statement, because `[[... > 0]]` created a file, with the name `0`, which, in fact, was useless and annoying.
This may resolve #16 